### PR TITLE
Make blog post layout full width

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1,0 +1,10 @@
+---
+---
+@import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin | default: 'default' }}";
+@import "minimal-mistakes";
+
+.page,
+.page__inner-wrap,
+.page__content {
+  max-width: 100%;
+}


### PR DESCRIPTION
## Summary
- add custom CSS overriding the theme's default max-width

## Testing
- `git status --short`